### PR TITLE
Enable fenced code blocks

### DIFF
--- a/c_src/nif/gb_markdown_analyzer.cc
+++ b/c_src/nif/gb_markdown_analyzer.cc
@@ -33,7 +33,7 @@ static void gb_markdown_normal_text(hoedown_buffer *ob, const hoedown_buffer *te
 
 #define GB_HOEDOWN_EXTENSIONS (hoedown_extensions) (HOEDOWN_EXT_DISABLE_INDENTED_CODE | HOEDOWN_EXT_SPACE_HEADERS | \
                                                     HOEDOWN_EXT_MATH_EXPLICIT | HOEDOWN_EXT_NO_INTRA_EMPHASIS | \
-                                                    HOEDOWN_EXT_TABLES)
+                                                    HOEDOWN_EXT_TABLES | HOEDOWN_EXT_FENCED_CODE)
 #define GB_MAX_NESTING 16
 
 #define DBG_HERE std::cout << __FILE__ << ":" << __LINE__ << "\n"


### PR DESCRIPTION
I really only need this for preserving newlines. With this turned off the code block tags ("```") would get passed through but any newlines would be collapsed since the content inside was treated as normal text. Once this is merged we can update the greenbar repo and improve this test: https://github.com/operable/greenbar/blob/master/test/markdown_test.exs#L29-L33
