### PR TITLE
Add support for fixed width strings and blocks

### DIFF
--- a/c_src/nif/gb_info_util.cc
+++ b/c_src/nif/gb_info_util.cc
@@ -58,6 +58,8 @@ namespace greenbar {
       return priv_data->gb_atom_text;
     case greenbar::MD_FIXED_WIDTH:
       return priv_data->gb_atom_fixed_width;
+    case greenbar::MD_FIXED_WIDTH_BLOCK:
+      return priv_data->gb_atom_fixed_width_block;
     case greenbar::MD_HEADER:
       return priv_data->gb_atom_header;
     case greenbar::MD_ITALICS:

--- a/c_src/nif/gb_info_util.cc
+++ b/c_src/nif/gb_info_util.cc
@@ -25,6 +25,12 @@ namespace greenbar {
     return retval;
   }
 
+  MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const std::string& text) {
+    auto retval = new MarkdownLeafInfo(info_type);
+    retval->set_text(text);
+    return retval;
+  }
+
   MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const hoedown_buffer* title, const hoedown_buffer* link) {
     auto retval = new MarkdownLeafInfo(info_type);
     if (title != nullptr) {

--- a/c_src/nif/gb_markdown_analyzer.cc
+++ b/c_src/nif/gb_markdown_analyzer.cc
@@ -130,7 +130,7 @@ static bool set_previous(const hoedown_renderer_data *data, greenbar::MarkdownIn
 static void gb_markdown_blockcode(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang,
                                   const hoedown_renderer_data *data) {
   auto collector = get_collector(data);
-  collector->push_back(greenbar::new_leaf(greenbar::MD_FIXED_WIDTH, text));
+  collector->push_back(greenbar::new_leaf(greenbar::MD_FIXED_WIDTH_BLOCK, text));
 }
 
 static void gb_markdown_header(hoedown_buffer *ob, const hoedown_buffer *content, int level,

--- a/c_src/nif/gb_markdown_analyzer.cc
+++ b/c_src/nif/gb_markdown_analyzer.cc
@@ -130,6 +130,14 @@ static bool set_previous(const hoedown_renderer_data *data, greenbar::MarkdownIn
 static void gb_markdown_blockcode(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_buffer *lang,
                                   const hoedown_renderer_data *data) {
   auto collector = get_collector(data);
+  if (text->size > 1) {
+    uint8_t last_char = text->data[text->size - 1];
+    if (last_char == '\n') {
+      std::string leaf_text = std::string((char*) text->data, text->size - 1);
+      collector->push_back(greenbar::new_leaf(greenbar::MD_FIXED_WIDTH_BLOCK, leaf_text));
+      return;
+    }
+  }
   collector->push_back(greenbar::new_leaf(greenbar::MD_FIXED_WIDTH_BLOCK, text));
 }
 

--- a/c_src/nif/gb_markdown_nif.cc
+++ b/c_src/nif/gb_markdown_nif.cc
@@ -70,6 +70,7 @@ static int on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM load_info) {
   priv_data->gb_atom_text = make_atom(env, "text");
   priv_data->gb_atom_newline = make_atom(env, "newline");
   priv_data->gb_atom_fixed_width = make_atom(env, "fixed_width");
+  priv_data->gb_atom_fixed_width_block = make_atom(env, "fixed_width_block");
   priv_data->gb_atom_header = make_atom(env, "header");
   priv_data->gb_atom_italics = make_atom(env, "italics");
   priv_data->gb_atom_bold = make_atom(env, "bold");

--- a/c_src/nif/include/gb_common.hpp
+++ b/c_src/nif/include/gb_common.hpp
@@ -11,6 +11,7 @@ typedef struct {
   ERL_NIF_TERM gb_atom_text;
   ERL_NIF_TERM gb_atom_newline;
   ERL_NIF_TERM gb_atom_fixed_width;
+  ERL_NIF_TERM gb_atom_fixed_width_block;
   ERL_NIF_TERM gb_atom_header;
   ERL_NIF_TERM gb_atom_italics;
   ERL_NIF_TERM gb_atom_bold;

--- a/c_src/nif/include/markdown_info.hpp
+++ b/c_src/nif/include/markdown_info.hpp
@@ -99,6 +99,7 @@ namespace greenbar {
 
   MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const hoedown_buffer* buffer);
   MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const hoedown_buffer* buffer, int info_level);
+  MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const std::string& text);
   MarkdownLeafInfo* new_leaf(MarkdownInfoType info_type, const hoedown_buffer* text, const hoedown_buffer* url);
 
   MarkdownLeafInfo* as_leaf(MarkdownInfo* info);

--- a/c_src/nif/include/markdown_info.hpp
+++ b/c_src/nif/include/markdown_info.hpp
@@ -15,6 +15,7 @@ namespace greenbar {
     MD_EOL,
     MD_TEXT,
     MD_FIXED_WIDTH,
+    MD_FIXED_WIDTH_BLOCK,
     MD_HEADER,
     MD_ITALICS,
     MD_BOLD,

--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,8 @@
 {deps, []}.
 
 {pre_hooks,
-  [{"(linux|darwin|solaris)", compile, "make -C c_src"},
-   {"(freebsd)", compile, "gmake -C c_src"}]}.
+  [{"(linux|darwin|solaris)", compile, "make -j2 -C c_src"},
+   {"(freebsd)", compile, "gmake -j2 -C c_src"}]}.
 {post_hooks,
-  [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-   {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+  [{"(linux|darwin|solaris)", clean, "make -j2 -C c_src clean"},
+   {"(freebsd)", clean, "gmake -j2 -C c_src clean"}]}.


### PR DESCRIPTION
This PR adds support for fixed-width blocks (triple ticks) and fixed width strings (single ticks).

Fixes operable/cog#1087
