### PR TITLE
Pull code blocks up into list item nodes during parsing

### DIFF
--- a/c_src/src/gb_markdown_analyzer.cc
+++ b/c_src/src/gb_markdown_analyzer.cc
@@ -347,7 +347,7 @@ static void gb_markdown_listitem(hoedown_buffer *ob, const hoedown_buffer *conte
       auto child = collector->back();
       auto child_type = child->get_type();
       if (child_type == MD_LIST_ITEM ||
-          ((first_child_type == MD_PARAGRAPH || first_child_type == MD_TEXT) && child_type == MD_PARAGRAPH)) {
+          ((first_child_type == MD_PARAGRAPH || first_child_type == MD_TEXT || first_child_type == MD_FIXED_WIDTH) && child_type == MD_PARAGRAPH)) {
         break;
       }
       if (child->line_terminator()) {


### PR DESCRIPTION
This fixes the incorrect parsing of the following template:

```
__People__

* `Patrick`
* `Shelton`
```

Was rendered incorrectly as:

```
   • *People*

`Patrick`
   • `Shelton`
```

Renders like the following with this fix:

```
*People*

   • `Patrick`
   • `Shelton`
```

Fixes https://github.com/operable/cog/issues/1259