### PR TITLE
Include missing <cstring> header for the memcpy function

### DIFF
--- a/c_src/include/md_node_base.hpp
+++ b/c_src/include/md_node_base.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <cstring>
 #include <vector>
 #include "erl_nif.h"
 #include "gb_common.hpp"


### PR DESCRIPTION
Hello. The compilation fails with the following message (tested with GCC 4, 5 & 6 series):

```
src/md_node_base.cc: In member function ‘virtual ERL_NIF_TERM greenbar::node2::MarkdownNode::decorate_term(ErlNifEnv*, ERL_NIF_TERM)’:
src/md_node_base.cc:10:53: error: ‘memcpy’ was not declared in this scope
         memcpy(text_bin, text_.c_str(), text_.size());
                                                     ^
Makefile:70: recipe for target 'src/md_node_base.o' failed
```

Including the <cstring> header fixes this issue.